### PR TITLE
[wip] attempting to highlight week in weekly mini-calendar (built on #1)

### DIFF
--- a/app/components/cal/day.go
+++ b/app/components/cal/day.go
@@ -84,6 +84,42 @@ func (d Day) Breadcrumb(prefix string, leaf string, shorten bool) string {
 	return items.Table(true)
 }
 
+func (d Day) NotesBreadcrumb(prefix string, leaf string, notesPageCount int, shorten bool) string {
+	wpref := ""
+	_, wn := d.Time.ISOWeek()
+	if wn > 50 && d.Time.Month() == time.January {
+		wpref = "fw"
+	}
+
+	dayLayout := "Monday, 2"
+	if shorten {
+		dayLayout = "Mon, 2"
+	}
+
+	dayItem := header.NewTextItem(d.Time.Format(dayLayout)).RefText(d.Time.Format(time.RFC3339))
+	items := header.Items{
+		header.NewIntItem(d.Time.Year()),
+		header.NewTextItem("Q" + strconv.Itoa(int(math.Ceil(float64(d.Time.Month())/3.)))),
+		header.NewMonthItem(d.Time.Month()).Shorten(shorten),
+		header.NewTextItem("Week " + strconv.Itoa(wn)).RefPrefix(wpref),
+	}
+
+	if len(leaf) > 0 {
+		// - breadcrumb for this page should say "Notes 1", "Notes 2", or "Notes 3"
+		// - hyperlink target for notes 2 and notes 3 should include 2 or 3 at the end respectively while
+		//   target for notes 1 should have no postfix and is the ref we link to from prev and next
+		refText := prefix + d.ref()
+		if notesPageCount > 1 {
+			refText = refText + strconv.Itoa(notesPageCount)
+		}
+		items = append(items, dayItem, header.NewTextItem(leaf+" "+strconv.Itoa(notesPageCount)).RefText(refText).Ref(true))
+	} else {
+		items = append(items, dayItem.Ref(true))
+	}
+
+	return items.Table(true)
+}
+
 func (d Day) LinkLeaf(prefix, leaf string) string {
 	return hyper.Link(prefix+d.ref(), leaf)
 }

--- a/app/components/cal/week.go
+++ b/app/components/cal/week.go
@@ -1,6 +1,7 @@
 package cal
 
 import (
+	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/kudrykv/latex-yearly-planner/app/components/header"
 	"github.com/kudrykv/latex-yearly-planner/app/components/hyper"
 	"github.com/kudrykv/latex-yearly-planner/app/tex"
+	"github.com/kudrykv/latex-yearly-planner/app/texx"
 )
 
 type Weeks []*Week
@@ -119,13 +121,24 @@ func selectStartWeek(year int, weekStart time.Weekday) Day {
 	return Day{Time: sow}
 }
 
-func (w *Week) WeekNumber(large interface{}) string {
+func (w *Week) WeekNumber(currentWeek, large interface{}) string {
+	log.Println("WeekNumber: currentWeek", currentWeek)
 	wn := w.weekNumber()
 	larg, _ := large.(bool)
 
 	itoa := strconv.Itoa(wn)
 	ref := w.ref()
 	if !larg {
+		log.Println("currentWeek", currentWeek)
+		if cw, ok := currentWeek.(Week); ok {
+			cwn := cw.weekNumber()
+			log.Println("wn", wn, "cwn", cwn)
+			if wn == cwn {
+				return texx.EmphCell(itoa)
+			}
+		} else {
+			log.Println("not ok")
+		}
 		return hyper.Link(ref, itoa)
 	}
 

--- a/app/components/cal/week.go
+++ b/app/components/cal/week.go
@@ -1,7 +1,6 @@
 package cal
 
 import (
-	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -122,22 +121,16 @@ func selectStartWeek(year int, weekStart time.Weekday) Day {
 }
 
 func (w *Week) WeekNumber(currentWeek, large interface{}) string {
-	log.Println("WeekNumber: currentWeek", currentWeek)
 	wn := w.weekNumber()
 	larg, _ := large.(bool)
 
 	itoa := strconv.Itoa(wn)
 	ref := w.ref()
 	if !larg {
-		log.Println("currentWeek", currentWeek)
-		if cw, ok := currentWeek.(Week); ok {
-			cwn := cw.weekNumber()
-			log.Println("wn", wn, "cwn", cwn)
-			if wn == cwn {
+		if cw, ok := currentWeek.(*Week); ok {
+			if cw.weekNumber() == wn {
 				return texx.EmphCell(itoa)
 			}
-		} else {
-			log.Println("not ok")
 		}
 		return hyper.Link(ref, itoa)
 	}

--- a/app/compose/daily.go
+++ b/app/compose/daily.go
@@ -8,7 +8,7 @@ import (
 
 var Daily = DailyStuff("", "")
 var DailyReflect = DailyStuff("Reflect", "Reflect")
-var DailyNotes = DailyStuff("More", "Notes")
+var DailyNotes = DailyStuffNotes("More", "Notes")
 
 func DailyStuff(prefix, leaf string) func(cfg config.Config, tpls []string) (page.Modules, error) {
 	return func(cfg config.Config, tpls []string) (page.Modules, error) {
@@ -40,6 +40,46 @@ func DailyStuff(prefix, leaf string) func(cfg config.Config, tpls []string) (pag
 								"Extra2":       extra2(cfg.ClearTopRightCorner, false, false, week, 0),
 							},
 						})
+					}
+				}
+			}
+		}
+
+		return modules, nil
+	}
+}
+
+func DailyStuffNotes(prefix, leaf string) func(cfg config.Config, tpls []string) (page.Modules, error) {
+	return func(cfg config.Config, tpls []string) (page.Modules, error) {
+		year := cal.NewYear(cfg.WeekStart, cfg.Year)
+		modules := make(page.Modules, 0, 366)
+
+		for _, quarter := range year.Quarters {
+			for _, month := range quarter.Months {
+				for _, week := range month.Weeks {
+					for _, day := range week.Days {
+						if day.Time.IsZero() {
+							continue
+						}
+						for i := 1; i <= 3; i++ { // make three pages of notes per day
+							modules = append(modules, page.Module{
+								Cfg: cfg,
+								Tpl: tpls[0],
+								Body: map[string]interface{}{
+									"Year":         year,
+									"Quarter":      quarter,
+									"Month":        month,
+									"Week":         week,
+									"Day":          day,
+									"Breadcrumb":   day.NotesBreadcrumb(prefix, leaf, i, cfg.ClearTopRightCorner && len(leaf) > 0),
+									"HeadingMOS":   day.HeadingMOS(prefix, leaf),
+									"SideQuarters": year.SideQuarters(day.Quarter()),
+									"SideMonths":   year.SideMonths(day.Month()),
+									"Extra":        day.PrevNext(prefix).WithTopRightCorner(cfg.ClearTopRightCorner),
+									"Extra2":       extra2(cfg.ClearTopRightCorner, false, false, week, 0),
+								},
+							})
+						}
 					}
 				}
 			}

--- a/tpls/_common_04_weekly_dotted.tpl
+++ b/tpls/_common_04_weekly_dotted.tpl
@@ -7,6 +7,7 @@
 {{- $day6 := index $days 5 -}}
 {{- $day7 := index $days 6 -}}
 {{- $today := .Body.Day -}}
+{{- $currentWeek := .Body.Week -}}
 
 \parbox{\myLenTriCol}{\myUnderline{ {{- $day1.WeekLink -}} }}%
 \hspace{\myLenTriColSep}%
@@ -36,6 +37,7 @@
 \begin{minipage}[t]{\myLenTriCol}
 \vspace{0pt}
 {{- if .Cfg.CalAfterSchedule -}}
-{{- template "monthTabularV2.tpl" dict "Month" .Body.Month "Today" $today -}}
+{{- template "monthTabularV2.tpl" dict "Month" .Body.Month "Week" $currentWeek "Today" $today -}}
 {{- end -}}
+{{- $currentWeek -}}
 \end{minipage}%

--- a/tpls/_common_04_weekly_dotted.tpl
+++ b/tpls/_common_04_weekly_dotted.tpl
@@ -37,7 +37,6 @@
 \begin{minipage}[t]{\myLenTriCol}
 \vspace{0pt}
 {{- if .Cfg.CalAfterSchedule -}}
-{{- template "monthTabularV2.tpl" dict "Month" .Body.Month "Week" $currentWeek "Today" $today -}}
+{{- template "monthTabularV2.tpl" dict "Month" .Body.Month "CurrentWeek" $currentWeek "Today" $today -}}
 {{- end -}}
-{{- $currentWeek -}}
 \end{minipage}%

--- a/tpls/monthTabularV2.tpl
+++ b/tpls/monthTabularV2.tpl
@@ -7,7 +7,7 @@
   {{ if $.Large -}} \hline {{- end }}
   {{ .Month.WeekHeader .Large }} \\ {{ if .Large -}} \noalign{\hrule height \myLenLineThicknessThick} {{- else -}} \hline {{- end}}
   {{- range $i, $week := .Month.Weeks }}
-  {{$week.WeekNumber $.Large}} &
+  {{$week.WeekNumber $.Week $.Large}} &
     {{- range $j, $day := $week.Days -}}
       {{- $day.Day $.Today $.Large -}}
       {{- if eq $j 6 -}}

--- a/tpls/monthTabularV2.tpl
+++ b/tpls/monthTabularV2.tpl
@@ -7,7 +7,7 @@
   {{ if $.Large -}} \hline {{- end }}
   {{ .Month.WeekHeader .Large }} \\ {{ if .Large -}} \noalign{\hrule height \myLenLineThicknessThick} {{- else -}} \hline {{- end}}
   {{- range $i, $week := .Month.Weeks }}
-  {{$week.WeekNumber $.Week $.Large}} &
+  {{$week.WeekNumber $.CurrentWeek $.Large}} &
     {{- range $j, $day := $week.Days -}}
       {{- $day.Day $.Today $.Large -}}
       {{- if eq $j 6 -}}


### PR DESCRIPTION
```
PLANNER_YEAR=2025 PASSES=1 TRANSLATION=english CFG="cfg/base.yaml,cfg/template_breadcrumb.yaml,cfg/rm2.base.yaml,cfg/rm2.breadcrumb.default.dailycal.yaml" NAME="rm2.breadcrumb.default.ampm.dailycal.dailygoals.moredailynotes.customdailyreview.weeklycal.dotted.2025" ./single.sh 2>&1 | tee tmp-log.txt
```

[rm2.breadcrumb.default.ampm.dailycal.dotted.customweek.moredailynotes1.2025.pdf](https://github.com/user-attachments/files/18172426/rm2.breadcrumb.default.ampm.dailycal.dotted.customweek.moredailynotes1.2025.pdf)

<details>
<summary>Adds mini-cal to weekly view with current week highlighted</summary>
<img width="819" alt="Screen Shot 2024-12-17 at 3 29 25 PM" src="https://github.com/user-attachments/assets/b60fa0b7-a0e7-43a4-9570-d23a22abcb94" />
</details>


<details>
<summary>Adds three pages of notes instead of one in daily "more" section</summary>
Previous and Next day breadcrumbs link to the first notes page.
No breadcrumbs to go to Note 2 and Note 3, but it's intuitive/easier to just swipe.
<img width="819" alt="Screen Shot 2024-12-17 at 3 29 06 PM" src="https://github.com/user-attachments/assets/060caa02-6412-41a5-a61f-3d54b00a3e1f" />
</details>

<details>
<summary>Use translations to change Review prompts</summary>
<img width="819" alt="Screen Shot 2024-12-17 at 3 29 15 PM" src="https://github.com/user-attachments/assets/7112925e-b1ad-4ad6-9b0a-9c2d402f75f7" />
</details>

<details>
<summary>Add daily 'Goals' section above 'Todo'</summary>
'Todo' is changed from 'Top Priorities' also  using translations
<img width="819" alt="Screen Shot 2024-12-17 at 3 28 58 PM" src="https://github.com/user-attachments/assets/e7111a29-1c33-42a7-9221-d0a0f04c6ca7" />
<summary>Adds three pages of notes instead of one in daily "more" section</summary>


